### PR TITLE
fix anon scoring

### DIFF
--- a/lib/supabase/proxy.ts
+++ b/lib/supabase/proxy.ts
@@ -52,8 +52,8 @@ export async function updateSession(request: NextRequest) {
     !user &&
     !request.nextUrl.pathname.startsWith("/login") &&
     !request.nextUrl.pathname.startsWith("/auth") &&
-    !request.nextUrl.pathname.startsWith("/score") &&
-    !request.nextUrl.pathname.startsWith("/api/score")
+    !/^\/score(?:\/|$)/.test(request.nextUrl.pathname) &&
+    !/^\/api\/score(?:\/|$)/.test(request.nextUrl.pathname)
   ) {
     // no user, potentially respond by redirecting the user to the login page
     const url = request.nextUrl.clone();


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Allow anonymous users to access scoring endpoints

- Add RLS policies for public bracket stage and match scoring

- Enable anonymous users to update bracket matches during bracket phase


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Anonymous User"] -->|Request /score or /api/score| B["Auth Middleware"]
  B -->|Skip redirect| C["Scoring Endpoint"]
  C -->|Query bracket_stage| D["RLS Policy Check"]
  D -->|Event status = bracket| E["Allow Read Access"]
  C -->|Update bracket_match| F["RLS Policy Check"]
  F -->|Event status = bracket| G["Allow Update Access"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>proxy.ts</strong><dd><code>Exclude scoring routes from auth redirect</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/supabase/proxy.ts

<ul><li>Added <code>/score</code> and <code>/api/score</code> pathname exceptions to authentication <br>check<br> <li> Allows unauthenticated users to access scoring routes without redirect</ul>


</details>


  </td>
  <td><a href="https://github.com/Dustin-Klein/dg-putting-league/pull/6/files#diff-8cd03fd3ec720aa748397575864914a09f0859dcd1a2fa619d3b44ecc1df3534">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>20240101000000_initial_schema.sql</strong><dd><code>Add public RLS policies for bracket scoring</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

supabase/migrations/20240101000000_initial_schema.sql

<ul><li>Added RLS policy for public read access to bracket stages when event <br>status is 'bracket'<br> <li> Added RLS policy for public update access to bracket matches when <br>event status is 'bracket'<br> <li> Enables anonymous users to view and update scoring during bracket <br>phase</ul>


</details>


  </td>
  <td><a href="https://github.com/Dustin-Klein/dg-putting-league/pull/6/files#diff-d18ff25f4b5eb318c9ded7e498d574744c922236f4b39baf2b06055bed801e39">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

