### PR TITLE
Fix typescript checks

### DIFF
--- a/lib/services/__tests__/scoring-service.test.ts
+++ b/lib/services/__tests__/scoring-service.test.ts
@@ -284,7 +284,10 @@ describe('Scoring Service', () => {
       const mockEvent = createMockEvent({ status: 'bracket' });
       (getEventByAccessCodeForBracket as jest.Mock).mockResolvedValue(mockEvent);
 
-      const result = await validateAccessCode('ABC123', existingClient as any);
+      const result = await validateAccessCode(
+        'ABC123',
+        existingClient as unknown as Parameters<typeof validateAccessCode>[1]
+      );
 
       expect(result).toEqual(mockEvent);
       expect(getEventByAccessCodeForBracket).toHaveBeenCalledWith(existingClient, 'ABC123');

--- a/lib/services/__tests__/test-utils.ts
+++ b/lib/services/__tests__/test-utils.ts
@@ -198,7 +198,6 @@ export function createMockEvent(overrides: Partial<MockEvent> = {}): MockEvent {
     qualification_round_enabled: false,
     created_at: '2024-01-01T00:00:00Z',
     putt_distance_ft: 15,
-    participant_count: 0,
     ...overrides,
   };
 }
@@ -225,10 +224,11 @@ export function createMockEventWithDetails(
   eventOverrides: Partial<MockEvent> = {},
   players: MockEventPlayer[] = []
 ): MockEventWithDetails {
+  const baseEvent = createMockEvent(eventOverrides);
   return {
-    ...createMockEvent(eventOverrides),
+    ...baseEvent,
     players,
-    participant_count: players.length,
+    participant_count: baseEvent.participant_count ?? players.length,
   };
 }
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Replace overly specific type cast with `any` in test

- Add missing `created_at` field to MockEventPlayer interface

- Add `putt_distance_ft` and `participant_count` fields to MockEvent

- Fix type casting for mock query builder chaining

- Update `access_code` type from nullable to required string


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Files"] -->|"Replace specific type casts"| B["Use any type"]
  A -->|"Add missing fields"| C["MockEventPlayer & MockEvent"]
  C -->|"created_at, putt_distance_ft"| D["Updated Interfaces"]
  A -->|"Fix type safety"| E["Query builder casting"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scoring-service.test.ts</strong><dd><code>Simplify type cast in validateAccessCode test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/services/__tests__/scoring-service.test.ts

<ul><li>Replace <code>MockSupabaseClient</code> type cast with <code>any</code> to resolve TypeScript <br>type compatibility issue</ul>


</details>


  </td>
  <td><a href="https://github.com/Dustin-Klein/dg-putting-league/pull/25/files#diff-abe8293e7fbef73928a6332eb8a7248076bf5cf43d1df8a0f8114c1a5f1fe279">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test-utils.ts</strong><dd><code>Add missing fields and fix type casts in mocks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/services/__tests__/test-utils.ts

<ul><li>Add <code>created_at</code> field to <code>MockEventPlayer</code> interface and implementation<br> <li> Add <code>putt_distance_ft</code> and <code>participant_count</code> fields to <code>MockEvent</code> <br>interface and implementation<br> <li> Update <code>access_code</code> type from <code>string | null</code> to <code>string</code> in MockEvent<br> <li> Fix type casting for mock query builder by using <code>unknown</code> intermediate <br>cast<br> <li> Update <code>MockEventWithDetails</code> to include <code>participant_count</code> field</ul>


</details>


  </td>
  <td><a href="https://github.com/Dustin-Klein/dg-putting-league/pull/25/files#diff-d4d5b73705d29e8ab677416eaeeda8cf74267cb8ee63d4ff4c76f40263420e8f">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

