### PR TITLE
fix bracket query performance issue

### DIFF
--- a/lib/repositories/bracket-repository.ts
+++ b/lib/repositories/bracket-repository.ts
@@ -566,14 +566,7 @@ export async function getMatchForScoringById(
   }));
 
   return {
-    id: matchWithFrames.data.id,
-    status: matchWithFrames.data.status,
-    round_id: matchWithFrames.data.round_id,
-    number: matchWithFrames.data.number,
-    lane_id: matchWithFrames.data.lane_id,
-    opponent1: matchWithFrames.data.opponent1,
-    opponent2: matchWithFrames.data.opponent2,
-    event_id: matchWithFrames.data.event_id,
+    ...matchWithFrames.data,
     frames: framesWithResults,
   } as SingleBracketMatchForScoring;
 }


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Refactored bracket match query to use two parallel queries instead of nested PostgREST query

- Avoids 3-level nesting timeout issues by separating frame results fetch

- Manually reconstructs frame results mapping to maintain data structure

- Improves query performance and reliability for scoring operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Single nested query<br/>3-level nesting"] -->|timeout issues| B["Performance problem"]
  C["Parallel queries<br/>Match + Frames"] -->|separate fetch| D["Frame Results"]
  D -->|manual mapping| E["Reconstructed data<br/>structure"]
  E -->|improved performance| F["Reliable scoring"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bracket-repository.ts</strong><dd><code>Split nested query into parallel queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/repositories/bracket-repository.ts

<ul><li>Replaced single nested PostgREST query with two parallel queries using <br><code>Promise.all()</code><br> <li> First query fetches bracket match with frames (without nested results)<br> <li> Second query separately fetches frame results filtered by <br>bracket_match_id<br> <li> Added manual mapping logic to reconstruct frame results by frame ID<br> <li> Returns properly structured <code>SingleBracketMatchForScoring</code> object with <br>assembled data</ul>


</details>


  </td>
  <td><a href="https://github.com/Dustin-Klein/dg-putting-league/pull/50/files#diff-c6441587e46703276f2aae80a02e54b2e04db617d051f5d20169627e67dcd775">+66/-26</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

